### PR TITLE
move switch.specs file generation to build.rs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
 /target
-
-
-#Added by cargo
-#
-#already existing elements were commented out
-
-#/target
 Cargo.lock
+switch.specs

--- a/switch.specs
+++ b/switch.specs
@@ -1,8 +1,0 @@
-%rename link                old_link
-
-*link:
-%(old_link) -T /home/leo60228/libnx.rs/switch.ld -pie --gc-sections -z text -z nodynamic-undefined-weak --build-id=sha1 --nx-module-name
-
-*startfile:
-crti%O%s crtbegin%O%s
-


### PR DESCRIPTION
This just removes the hard-coded path in the switch.specs file and makes it portable.